### PR TITLE
implemented exception handling for changing timeout visibility / hear…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ test.js
 coverage
 dist
 .nyc_output
+*.tgz

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -275,7 +275,7 @@ export class Consumer extends EventEmitter {
 
   private async changeVisabilityTimeout(message: SQSMessage, timeout: number): Promise<PromiseResult<any, AWSError>> {
     try {
-      return this.sqs
+      return await this.sqs
         .changeMessageVisibility({
           QueueUrl: this.queueUrl,
           ReceiptHandle: message.ReceiptHandle,
@@ -283,7 +283,7 @@ export class Consumer extends EventEmitter {
         })
         .promise();
     } catch (err) {
-      this.emit('error', err, message);
+      this.emit('error', toSQSError(err, `Error changing visibility timeout: ${err.message}`), message);
     }
   }
 
@@ -397,11 +397,11 @@ export class Consumer extends EventEmitter {
       }))
     };
     try {
-      return this.sqs
+      return await this.sqs
         .changeMessageVisibilityBatch(params)
         .promise();
     } catch (err) {
-      this.emit('error', err, messages);
+      this.emit('error', toSQSError(err, `Error changing visibility timeout: ${err.message}`), messages);
     }
   }
 


### PR DESCRIPTION
Monday task: 
https://patternarch.monday.com/boards/2433534228/pulses/2483876310

## Summary
Forked [sqs-consumer](https://github.com/BBC/sqs-consumer) and implemented a PR that has been open for some time (https://github.com/bbc/sqs-consumer/pull/280) 

Essentially, the issue is that sometimes the heartbeatInterval will fire its changeVisibilityTimeout request after a message has been deleted (the receiptHandleID is invalid). This returns an error from SQS:

`"Receipt Handle is invalid. Reason: Message does not exist or is not available for visibility timeout change."`

that was not being handled due to not returning an await statement within an async function (see diff). We should no longer be getting unhandled exceptions in the logs.

## Testing plan 
1. Set heartbeat interval and visbilityTimeout to a very low value in ct_node (e.g., 1 and 5 respectively) 
2. Run daylight analysis
3. Confirm that `change visibility error` is being logged instead of "unhandled exceptions" 
